### PR TITLE
Add slash command functionality to toggle minimap icon

### DIFF
--- a/RepHub.lua
+++ b/RepHub.lua
@@ -230,6 +230,17 @@ function RepHub:HandleCommand(input)
         RepHub:ResetDB()
     elseif input == "csv" then
         RepHub:csvExport()
+    elseif input == "minimap" then
+        self.db.profile.minimap.hide = not self.db.profile.minimap.hide
+        if self.db.profile.minimap.hide then
+            LibDBIcon:Hide("RepHub")
+            print("RepHub: Minimap icon hidden. Use /rephub minimap to show it again.")
+        else
+            LibDBIcon:Show("RepHub")
+            print("RepHub: Minimap icon shown.")
+        end
+    else
+        print("RepHub commands: /rephub minimap | /rephub csv | /rephub resetdb")
     end
 end
 


### PR DESCRIPTION
### Summary
Adds `/rephub minimap` to toggle the minimap icon on and off. The saved variable (`minimap.hide`) and LibDBIcon wiring were already in place but had no user-facing control. This also adds a usage hint when `/rephub` is run with no arguments or an unrecognized argument.

### Motivation
RepHub registers both a LibDataBroker data object and a LibDBIcon minimap button. For anyone using an LDB display addon (Titan Panel, Bazooka, ElvUI DataTexts, etc.), the minimap icon is redundant. There was no way to hide it without manually editing saved variables.